### PR TITLE
refactor(a11y): Complete TalkBack semantics for remaining UI components (Switch, MCP, Models)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
@@ -517,7 +517,7 @@ private fun ColumnScope.ModelList(
                             ) {
                                 Icon(
                                     HeartIcon,
-                                    contentDescription = null,
+                                    contentDescription = stringResource(R.string.chat_message_remove_favorite),
                                     modifier = Modifier.size(20.dp),
                                     tint = MaterialTheme.colorScheme.primary,
                                 )
@@ -602,14 +602,14 @@ private fun ColumnScope.ModelList(
                             if (favorite) {
                                 Icon(
                                     HeartIcon,
-                                    contentDescription = null,
+                                    contentDescription = stringResource(R.string.chat_message_remove_favorite),
                                     modifier = Modifier.size(20.dp),
                                     tint = MaterialTheme.colorScheme.primary,
                                 )
                             } else {
                                 Icon(
                                     imageVector = HugeIcons.Favourite,
-                                    contentDescription = null,
+                                    contentDescription = stringResource(R.string.chat_message_add_favorite),
                                     modifier = Modifier.size(20.dp)
                                 )
                             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ChainOfThought.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ChainOfThought.kt
@@ -392,7 +392,7 @@ private class ChainOfThoughtScopeImpl : ChainOfThoughtScope {
                 } else if (hasContent) {
                     Icon(
                         imageVector = if (expanded) HugeIcons.ArrowUp01 else HugeIcons.ArrowDown01,
-                        contentDescription = null,
+                        contentDescription = stringResource(if (expanded) R.string.code_block_collapse else R.string.code_block_expand),
                         modifier = Modifier.size(16.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
@@ -3,7 +3,8 @@ package me.rerere.rikkahub.ui.components.ui
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.ui.semantics.Role
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -97,13 +98,14 @@ fun Switch(
             .size(width = dimensions.trackWidth, height = dimensions.trackHeight)
             .clip(RoundedCornerShape(50))
             .background(currentTrackColor)
-            .clickable(
+            .toggleable(
+                value = checked,
                 enabled = enabled,
+                role = Role.Switch,
                 indication = null,
-                interactionSource = remember { MutableInteractionSource() }
-            ) {
-                onCheckedChange(!checked)
-            },
+                interactionSource = remember { MutableInteractionSource() },
+                onValueChange = onCheckedChange
+            ),
         contentAlignment = Alignment.CenterStart
     ) {
         Box(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ToggleSurface.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ToggleSurface.kt
@@ -8,6 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -24,7 +27,9 @@ fun ToggleSurface(
         onClick = onClick,
         color = Color.Transparent,
         contentColor = contentColor,
-        modifier = modifier,
+        modifier = modifier.semantics {
+            toggleableState = ToggleableState(checked)
+        },
         shape = shape,
         tonalElevation = 0.dp,
         shadowElevation = 0.dp

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
@@ -972,7 +972,7 @@ private fun McpToolCard(
                 ) {
                     Icon(
                         if (expanded) HugeIcons.ArrowUp01 else HugeIcons.ArrowDown01,
-                        contentDescription = null,
+                        contentDescription = stringResource(if (expanded) R.string.code_block_collapse else R.string.code_block_expand),
                         modifier = Modifier.size(16.dp)
                     )
                 }


### PR DESCRIPTION
## ♿ TalkBack Accessibility Semantics (v2)

### What this does
Scopes accessibility semantics strictly to the high-value areas highlighted in review: custom interactive controls and standalone toggle buttons.

### Key Changes:
1. **Switch (`Switch.kt`):** Replaced custom clickable/semantics with native `Modifier.toggleable(value, enabled, role = Role.Switch, ...)`.
2. **Toggle Chips (`ToggleSurface.kt`):** Added `toggleableState = ToggleableState(checked)` inside `ToggleSurface` semantics so all toggleable chips (Web Search, MCP, Reasoning) automatically announce their checked/unchecked state without duplicating icon descriptions.
3. **Model List (`ModelList.kt`):** 
   - Reused existing 6-locale strings (`chat_message_remove_favorite` and `chat_message_add_favorite`).
   - Cleaned up Favorite toggle button scopes and branch conditions.
4. **Tool & Thoughts Expansion (`SettingMcpPage.kt` & `ChainOfThought.kt`):** Reused existing 6-locale strings (`code_block_collapse` and `code_block_expand`).
5. **No Double-Announcements:** Retained `contentDescription = null` on icons sitting alongside visible text inside merged clickables.

---
Contributed by: [@AbdulAziz-Hatem](https://github.com/AbdulAziz-Hatem)
